### PR TITLE
Moinmoin config: setting client_max_body_size to 200M

### DIFF
--- a/moinmoin.conf
+++ b/moinmoin.conf
@@ -20,10 +20,10 @@ upstream uwsgicluster {
 
 # HTTPS server
 server {
-    listen 80;
+  listen 80;
   proxy_cache mmcache;
   server_name  localhost;
-
+  client_max_body_size 200M;
 
   location / {
     proxy_cache_valid any 1m;


### PR DESCRIPTION
Currently in master file upload is severely restricted due to server configuration.

Bumped up to an extremely generous 200M which is same as proxy config. Probably not sane in a production environment and it appears that multipart uploads might be borked in moin moin for whatever reason? 
